### PR TITLE
Feat/colon password

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-auth"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,7 @@ pub async fn get_token(log: &Logging, name: String) -> Result<String, Box<dyn st
         Err(e) => panic!("invalid UTF-8 sequence: {}", e),
     };
     // get user and password form json
-    let user = s.split(":").nth(0).unwrap();
-    let pwd = s.split(":").nth(1).unwrap();
+    let (user, pwd) = s.split_once(":").unwrap();
     let token_url = match name.as_str() {
         "registry.redhat.io" => "https://sso.redhat.com/auth/realms/rhcc/protocol/redhat-docker-v2/auth?service=docker-registry&client_id=curl&scope=repository:rhel:pull".to_string(),
         "quay.io" => {


### PR DESCRIPTION
This PR parses the auth json in a way that supports passwords with colons (`:`) inside them.

Without the change introduced in this PR, the error encountered when using a password with colon inside it (e.g. `my:test:password`) is the following:
```
 [ DEBUG 2024-08-29 15:43:46.008 ]   : using auth file $XDG_RUNTIME_DIR/containers/auth.json
 [ ERROR 2024-08-29 15:43:46.339 ]   : Some(
    MirrorError {
        details: "get_auth_json \"could not parse access_token for registry.redhat.io\"",
    },
)
```

This is due to splitting on colon and only taking the first element of the password and truncating the rest.

This PR uses `split_once` instead and handles the variable assignment in one line.

I was trying to figure out how to make a test case, but gave up :sweat_smile: Sorry!