### PR TITLE
Update logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "mirror-auth"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "async-trait",
  "base64",
  "custom-logger",
+ "log",
  "mirror-error",
  "mockito",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,10 +202,12 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "custom-logger"
-version = "0.1.4"
-source = "git+https://github.com/lmzuccarelli/rust-custom-logger?branch=main#f0ab24a95fdad4ed0df9f217f6add076f1d34897"
+version = "0.2.0"
+source = "git+https://github.com/lmzuccarelli/rust-custom-logger?branch=main#879eeefe99d0ea900984b0df817bce932b76caf9"
 dependencies = [
  "chrono",
+ "colored",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-auth"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = { version = "0.4", features = ["std"] }
 serial_test = "2.0.0"
 tokio-test = "0.4.3"
 mockito = "1.2.0"
-custom-logger = { git = "https://github.com/lmzuccarelli/rust-custom-logger", branch = "main", version = "0.1.4" }
+custom-logger = { git = "https://github.com/lmzuccarelli/rust-custom-logger", branch = "main", version = "0.2.0" }
 
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = { version = "0.21"}
-custom-logger = { git = "https://github.com/lmzuccarelli/rust-custom-logger", branch = "main", version = "0.1.4" }
+base64 = { version = "0.21" }
 mirror-error = { git = "https://github.com/lmzuccarelli/rust-mirror-error", branch = "main", version = "0.1.0" }
 urlencoding = "2.1.3"
 serde = "1.0.196"
@@ -15,11 +14,13 @@ serde_derive = "1.0.196"
 serde_json = "1.0.113"
 reqwest = { version = "0.11.22", features = ["json"] }
 async-trait = "0.1.74"
+log = { version = "0.4", features = ["std"] }
 
 [dev-dependencies]
 serial_test = "2.0.0"
-tokio-test = "0.4.3" 
+tokio-test = "0.4.3"
 mockito = "1.2.0"
+custom-logger = { git = "https://github.com/lmzuccarelli/rust-custom-logger", branch = "main", version = "0.1.4" }
 
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,9 +315,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_get_token_pass() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
+        let _ = Logging::new().with_level(LevelFilter::Trace).init();
 
         let fake = setup_mock();
         let res = aw!(get_token(
@@ -441,9 +439,7 @@ mod tests {
 
     #[test]
     fn get_credentials_file_pass() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
+        let _ = Logging::new().with_level(LevelFilter::Trace).init();
         let t_impl = ImplTokenInterface {};
         let res = aw!(t_impl.get_credentials(Some("tests/containers/auth.json".to_string())));
         assert_eq!(res.is_ok(), true);
@@ -451,9 +447,7 @@ mod tests {
 
     #[test]
     fn get_credentials_file_fail() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
+        let _ = Logging::new().with_level(LevelFilter::Trace).init();
         let t_impl = ImplTokenInterface {};
         let res_f = aw!(t_impl.get_credentials(Some("nada".to_string())));
         assert_eq!(res_f.is_ok(), true);
@@ -461,9 +455,7 @@ mod tests {
 
     #[test]
     fn get_credentials_xdg_pass() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
+        let _ = Logging::new().with_level(LevelFilter::Trace).init();
         unsafe {
             env::set_var("XDG_RUNTIME_DIR", "tests");
         }


### PR DESCRIPTION
* Use log façade from the `log` crate
* Move custom-logger to test-only dep
* Remove `log` param from interface API